### PR TITLE
Update project to package as a .NET tool

### DIFF
--- a/DependencyUpdated/DependencyUpdated.csproj
+++ b/DependencyUpdated/DependencyUpdated.csproj
@@ -5,7 +5,10 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
+        
         <PackageId>DependencyUpdatedTool</PackageId>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>dut</ToolCommandName>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Enabled tool packaging by adding PackAsTool and ToolCommandName properties. This allows the project to be installed and used as a command-line tool with the command 'dut'.