### PR TITLE
Update PackageId to DependencyUpdaterTool

### DIFF
--- a/DependencyUpdated/DependencyUpdated.csproj
+++ b/DependencyUpdated/DependencyUpdated.csproj
@@ -6,7 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         
-        <PackageId>DependencyUpdatedTool</PackageId>
+        <PackageId>DependencyUpdaterTool</PackageId>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>dut</ToolCommandName>
     </PropertyGroup>


### PR DESCRIPTION
Corrected the PackageId from DependencyUpdatedTool to DependencyUpdaterTool in the project file. This ensures consistency with the naming conventions throughout the project.