### PR TITLE
Update project handling to support multiple directories

### DIFF
--- a/src/DependencyUpdated.Core/Config/Project.cs
+++ b/src/DependencyUpdated.Core/Config/Project.cs
@@ -10,6 +10,8 @@ public sealed class Project : IValidatableObject
 
     public string Name { get; set; } = default!;
 
+    public bool EachDirectoryAsSeparate { get; set; } = false;
+
     public string[] DependencyConfigurations { get; set; } = [];
     
     public string[] Directories { get; set; } = [];
@@ -28,9 +30,14 @@ public sealed class Project : IValidatableObject
             yield return new ValidationResult($"{nameof(Directories)} cannot be empty");
         }
 
-        if (string.IsNullOrEmpty(Name))
+        if (!EachDirectoryAsSeparate && string.IsNullOrEmpty(Name))
         {
-            yield return new ValidationResult($"{nameof(Name)} must be provided");
+            yield return new ValidationResult($"{nameof(Name)} must be provided when {nameof(EachDirectoryAsSeparate)} is not set");
+        }
+        
+        if (EachDirectoryAsSeparate && !string.IsNullOrEmpty(Name))
+        {
+            yield return new ValidationResult($"{nameof(Name)} must not be provided when {nameof(EachDirectoryAsSeparate)} is set");
         }
 
         if (Groups.Length == 0)

--- a/src/DependencyUpdated.Core/IProjectUpdater.cs
+++ b/src/DependencyUpdated.Core/IProjectUpdater.cs
@@ -4,11 +4,11 @@ namespace DependencyUpdated.Core;
 
 public interface IProjectUpdater
 {
-    Task<ICollection<DependencyDetails>> ExtractAllPackagesThatNeedToBeUpdated(string fullPath,
+    Task<ICollection<DependencyDetails>> ExtractAllPackagesThatNeedToBeUpdated(IReadOnlyCollection<string> fullPath,
         Project projectConfiguration);
 
     IReadOnlyCollection<string> GetAllProjectFiles(string searchPath);
 
-    IReadOnlyCollection<UpdateResult> HandleProjectUpdate(string fullPath,
+    IReadOnlyCollection<UpdateResult> HandleProjectUpdate(IReadOnlyCollection<string> fullPath,
         ICollection<DependencyDetails> dependenciesToUpdate);
 }

--- a/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
+++ b/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
@@ -144,7 +144,9 @@ internal sealed class AzureDevOps(TimeProvider timeProvider, IOptions<UpdaterCon
 
     private static string CreateGitBranchName(string projectName, string branchName, string group)
     {
-        return $"{projectName.ToLower()}/{branchName.ToLower()}/{group.ToLower().Replace(".", "/").Replace("*", "asterix")}";
+        var newBranchName = $"{branchName.ToLower()}/{projectName.ToLower()}/{group.ToLower()}";
+        newBranchName = newBranchName.Replace(".", "/").Replace("*", "asterix");
+        return newBranchName;
     }
 
     private Branch? GetGitBranch(Repository repo, string branchName)

--- a/src/DependencyUpdated/config.json
+++ b/src/DependencyUpdated/config.json
@@ -14,8 +14,9 @@
     "Projects": [
       {
         "Type": "DotNet",
-        "Name": "DotNetProjects",
+        "Name": "",
         "Version": "Major",
+        "EachDirectoryAsSeparate": true,
         "DependencyConfigurations": [
         ],
         "Directories": [

--- a/tests/DependencyUpdated.Projects.DotNet.UnitTests/DotNetUpdaterTests.cs
+++ b/tests/DependencyUpdated.Projects.DotNet.UnitTests/DotNetUpdaterTests.cs
@@ -54,7 +54,7 @@ public class DotNetUpdaterTests
         };
         
         // Act
-        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(path, config);
+        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(new[] { path }, config);
         
         // Assert
         using (new AssertionScope())
@@ -76,7 +76,7 @@ public class DotNetUpdaterTests
         };
         
         // Act
-        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(path, config);
+        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(new[] { path }, config);
         
         // Assert
         using (new AssertionScope())
@@ -98,7 +98,7 @@ public class DotNetUpdaterTests
         };
         
         // Act
-        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(path, config);
+        var packages = await _target.ExtractAllPackagesThatNeedToBeUpdated(new[] { path }, config);
         
         // Assert
         using (new AssertionScope())


### PR DESCRIPTION
Refactored the code to handle multiple project directories more efficiently. Introduced a new flag, `EachDirectoryAsSeparate`, in the configuration to treat each directory as a separate project. Updated method signatures to accept collections of paths and adjusted various components for enhanced compliance and maintainability.