### PR TITLE
Extract Updater login into separate class.

### DIFF
--- a/src/DependencyUpdated.Core/Config/Project.cs
+++ b/src/DependencyUpdated.Core/Config/Project.cs
@@ -1,3 +1,4 @@
+using DependencyUpdated.Core.Models.Enums;
 using System.ComponentModel.DataAnnotations;
 
 namespace DependencyUpdated.Core.Config;

--- a/src/DependencyUpdated.Core/Config/UpdaterConfig.cs
+++ b/src/DependencyUpdated.Core/Config/UpdaterConfig.cs
@@ -1,3 +1,4 @@
+using DependencyUpdated.Core.Models.Enums;
 using System.ComponentModel.DataAnnotations;
 
 namespace DependencyUpdated.Core.Config;

--- a/src/DependencyUpdated.Core/Interfaces/IProjectUpdater.cs
+++ b/src/DependencyUpdated.Core/Interfaces/IProjectUpdater.cs
@@ -1,6 +1,7 @@
 using DependencyUpdated.Core.Config;
+using DependencyUpdated.Core.Models;
 
-namespace DependencyUpdated.Core;
+namespace DependencyUpdated.Core.Interfaces;
 
 public interface IProjectUpdater
 {

--- a/src/DependencyUpdated.Core/Interfaces/IRepositoryProvider.cs
+++ b/src/DependencyUpdated.Core/Interfaces/IRepositoryProvider.cs
@@ -1,4 +1,6 @@
-namespace DependencyUpdated.Core;
+using DependencyUpdated.Core.Models;
+
+namespace DependencyUpdated.Core.Interfaces;
 
 public interface IRepositoryProvider
 {

--- a/src/DependencyUpdated.Core/Models/DependencyDetails.cs
+++ b/src/DependencyUpdated.Core/Models/DependencyDetails.cs
@@ -1,3 +1,3 @@
-﻿namespace DependencyUpdated.Core;
+﻿namespace DependencyUpdated.Core.Models;
 
 public record DependencyDetails(string Name, Version Version);

--- a/src/DependencyUpdated.Core/Models/Enums/ProjectType.cs
+++ b/src/DependencyUpdated.Core/Models/Enums/ProjectType.cs
@@ -1,0 +1,6 @@
+namespace DependencyUpdated.Core.Models.Enums;
+
+public enum ProjectType
+{
+    DotNet = 1,
+}

--- a/src/DependencyUpdated.Core/Models/Enums/RepositoryType.cs
+++ b/src/DependencyUpdated.Core/Models/Enums/RepositoryType.cs
@@ -1,4 +1,4 @@
-namespace DependencyUpdated.Core;
+namespace DependencyUpdated.Core.Models.Enums;
 
 public enum RepositoryType
 {

--- a/src/DependencyUpdated.Core/Models/Enums/VersionUpdateType.cs
+++ b/src/DependencyUpdated.Core/Models/Enums/VersionUpdateType.cs
@@ -1,4 +1,4 @@
-namespace DependencyUpdated.Core;
+namespace DependencyUpdated.Core.Models.Enums;
 
 public enum VersionUpdateType
 {

--- a/src/DependencyUpdated.Core/Models/UpdateResult.cs
+++ b/src/DependencyUpdated.Core/Models/UpdateResult.cs
@@ -1,3 +1,3 @@
-namespace DependencyUpdated.Core;
+namespace DependencyUpdated.Core.Models;
 
 public record UpdateResult(string PackageName, string OldVersion, string NewVersion);

--- a/src/DependencyUpdated.Core/ProjectType.cs
+++ b/src/DependencyUpdated.Core/ProjectType.cs
@@ -1,6 +1,0 @@
-namespace DependencyUpdated.Core;
-
-public enum ProjectType
-{
-    DotNet = 1,
-}

--- a/src/DependencyUpdated.Core/Updater.cs
+++ b/src/DependencyUpdated.Core/Updater.cs
@@ -1,0 +1,76 @@
+using DependencyUpdated.Core.Config;
+using DependencyUpdated.Core.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using System.IO.Enumeration;
+
+namespace DependencyUpdated.Core;
+
+public sealed class Updater(IServiceProvider serviceProvider, IOptions<UpdaterConfig> config)
+{
+    public async Task DoUpdate()
+    {
+        var repositoryProvider =
+            serviceProvider.GetRequiredKeyedService<IRepositoryProvider>(config.Value.RepositoryType);
+        var repositoryPath = Environment.CurrentDirectory;
+        repositoryProvider.SwitchToDefaultBranch(repositoryPath);
+
+        foreach (var configEntry in config.Value.Projects)
+        {
+            var updater = serviceProvider.GetRequiredKeyedService<IProjectUpdater>(configEntry.Type);
+
+            foreach (var directory in configEntry.Directories)
+            {
+                if (!Path.Exists(directory))
+                {
+                    throw new FileNotFoundException("Search path not found", directory);
+                }
+
+                var projectFiles = updater.GetAllProjectFiles(directory);
+                var allDependenciesToUpdate =
+                    await updater.ExtractAllPackagesThatNeedToBeUpdated(projectFiles, configEntry);
+
+                if (allDependenciesToUpdate.Count == 0)
+                {
+                    continue;
+                }
+
+                var uniqueListOfDependencies = allDependenciesToUpdate.DistinctBy(x => x.Name).ToList();
+                var projectName = ResolveProjectName(configEntry, directory);
+                foreach (var group in configEntry.Groups)
+                {
+                    var matchesForGroup = uniqueListOfDependencies
+                        .Where(x => FileSystemName.MatchesSimpleExpression(group, x.Name)).ToArray();
+                    if (matchesForGroup.Length == 0)
+                    {
+                        continue;
+                    }
+
+                    uniqueListOfDependencies.RemoveAll(x => FileSystemName.MatchesSimpleExpression(group, x.Name));
+                    repositoryProvider.SwitchToUpdateBranch(repositoryPath, projectName, group);
+
+                    var allUpdates = updater.HandleProjectUpdate(projectFiles, matchesForGroup);
+                    if (allUpdates.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    repositoryProvider.CommitChanges(repositoryPath, projectName, group);
+                    await repositoryProvider.SubmitPullRequest(allUpdates.DistinctBy(x => x.PackageName).ToArray(),
+                        projectName, group);
+                    repositoryProvider.SwitchToDefaultBranch(repositoryPath);
+                }
+            }
+        }
+    }
+    
+    private static string ResolveProjectName(Project project, string directory)
+    {
+        if (!project.EachDirectoryAsSeparate)
+        {
+            return project.Name;
+        }
+
+        return Path.GetFileName(directory);
+    }
+}

--- a/src/DependencyUpdated.Projects.DotNet/ConfigureServices.cs
+++ b/src/DependencyUpdated.Projects.DotNet/ConfigureServices.cs
@@ -1,4 +1,5 @@
-using DependencyUpdated.Core;
+using DependencyUpdated.Core.Interfaces;
+using DependencyUpdated.Core.Models.Enums;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DependencyUpdated.Projects.DotNet;

--- a/src/DependencyUpdated.Projects.DotNet/DotNetUpdater.cs
+++ b/src/DependencyUpdated.Projects.DotNet/DotNetUpdater.cs
@@ -1,5 +1,7 @@
-﻿using DependencyUpdated.Core;
-using DependencyUpdated.Core.Config;
+﻿using DependencyUpdated.Core.Config;
+using DependencyUpdated.Core.Interfaces;
+using DependencyUpdated.Core.Models;
+using DependencyUpdated.Core.Models.Enums;
 using Microsoft.Extensions.Caching.Memory;
 using NuGet.Common;
 using NuGet.Configuration;

--- a/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
+++ b/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
@@ -1,5 +1,6 @@
-using DependencyUpdated.Core;
 using DependencyUpdated.Core.Config;
+using DependencyUpdated.Core.Interfaces;
+using DependencyUpdated.Core.Models;
 using DependencyUpdated.Repositories.AzureDevOps.Dto;
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;

--- a/src/DependencyUpdated.Repositories.AzureDevOps/ConfigureServices.cs
+++ b/src/DependencyUpdated.Repositories.AzureDevOps/ConfigureServices.cs
@@ -1,11 +1,12 @@
-using DependencyUpdated.Core;
+using DependencyUpdated.Core.Interfaces;
+using DependencyUpdated.Core.Models.Enums;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DependencyUpdated.Repositories.AzureDevOps;
 
 public static class ConfigureServices
 {
-    public static IServiceCollection RegisterGithub(this IServiceCollection serviceCollection)
+    public static IServiceCollection RegisterAzureDevOps(this IServiceCollection serviceCollection)
     {
         serviceCollection.AddKeyedSingleton<IRepositoryProvider, AzureDevOps>(RepositoryType.AzureDevOps);
 

--- a/src/DependencyUpdated/Program.cs
+++ b/src/DependencyUpdated/Program.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Serilog;
 using System.ComponentModel.DataAnnotations;
-using System.IO.Enumeration;
 using ILogger = Serilog.ILogger;
 
 namespace DependencyUpdated;
@@ -37,68 +36,9 @@ public static class Program
             throw new OptionsValidationException(nameof(UpdaterConfig), typeof(UpdaterConfig),
                 validationResult.Where(x => !string.IsNullOrEmpty(x.ErrorMessage)).Select(x => x.ErrorMessage!));
         }
-        
-        var repositoryProvider =
-            _serviceProvider.GetRequiredKeyedService<IRepositoryProvider>(config.Value.RepositoryType);
-        var repositoryPath = Environment.CurrentDirectory;
-        repositoryProvider.SwitchToDefaultBranch(repositoryPath);
 
-        foreach (var configEntry in config.Value.Projects)
-        {
-            var updater = _serviceProvider.GetRequiredKeyedService<IProjectUpdater>(configEntry.Type);
-
-            foreach (var directory in configEntry.Directories)
-            {
-                if (!Path.Exists(directory))
-                {
-                    throw new FileNotFoundException("Search path not found", directory);
-                }
-
-                var projectFiles = updater.GetAllProjectFiles(directory);
-                var allDependenciesToUpdate =
-                    await updater.ExtractAllPackagesThatNeedToBeUpdated(projectFiles, configEntry);
-
-                if (allDependenciesToUpdate.Count == 0)
-                {
-                    continue;
-                }
-
-                var uniqueListOfDependencies = allDependenciesToUpdate.DistinctBy(x => x.Name).ToList();
-                var projectName = ResolveProjectName(configEntry, directory);
-                foreach (var group in configEntry.Groups)
-                {
-                    var matchesForGroup = uniqueListOfDependencies
-                        .Where(x => FileSystemName.MatchesSimpleExpression(group, x.Name)).ToArray();
-                    if (matchesForGroup.Length == 0)
-                    {
-                        continue;
-                    }
-                    
-                    uniqueListOfDependencies.RemoveAll(x => FileSystemName.MatchesSimpleExpression(group, x.Name));
-                    repositoryProvider.SwitchToUpdateBranch(repositoryPath, projectName, group);
-
-                    var allUpdates = updater.HandleProjectUpdate(projectFiles, matchesForGroup);
-                    if (allUpdates.Count == 0)
-                    {
-                        continue;
-                    }
-
-                    repositoryProvider.CommitChanges(repositoryPath, projectName, group);
-                    await repositoryProvider.SubmitPullRequest(allUpdates.DistinctBy(x => x.PackageName).ToArray(), projectName, group);
-                    repositoryProvider.SwitchToDefaultBranch(repositoryPath);
-                }
-            }
-        }
-    }
-
-    private static string ResolveProjectName(Project project, string directory)
-    {
-        if (!project.EachDirectoryAsSeparate)
-        {
-            return project.Name;
-        }
-
-        return Path.GetFileName(directory);
+        var updater = ActivatorUtilities.CreateInstance<Updater>(_serviceProvider);
+        await updater.DoUpdate();
     }
 
     private static void Configure(Options appOptions)
@@ -122,7 +62,7 @@ public static class Program
             .AddSingleton(TimeProvider.System)
             .AddMemoryCache()
             .RegisterDotNetServices()
-            .RegisterGithub()
+            .RegisterAzureDevOps()
             .AddOptions<UpdaterConfig>().Bind(_configuration.GetSection("UpdaterConfig"));
 
         _serviceProvider = services.BuildServiceProvider();

--- a/tests/DependencyUpdated.Projects.DotNet.UnitTests/DotNetUpdaterTests.cs
+++ b/tests/DependencyUpdated.Projects.DotNet.UnitTests/DotNetUpdaterTests.cs
@@ -1,5 +1,6 @@
-using DependencyUpdated.Core;
 using DependencyUpdated.Core.Config;
+using DependencyUpdated.Core.Models;
+using DependencyUpdated.Core.Models.Enums;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.Extensions.Caching.Memory;


### PR DESCRIPTION
Move various enums and interfaces to organized subdirectories under Models and Interfaces namespaces. Extract the update logic from the Program class into a new, dedicated Updater class to improve code modularity and maintainability. Also, update affected import statements accordingly.