### PR TITLE
Refactor: Add reset before switching to default branch

### DIFF
--- a/src/DependencyUpdated.Core/Interfaces/IRepositoryProvider.cs
+++ b/src/DependencyUpdated.Core/Interfaces/IRepositoryProvider.cs
@@ -4,7 +4,7 @@ namespace DependencyUpdated.Core.Interfaces;
 
 public interface IRepositoryProvider
 {
-    public void SwitchToDefaultBranch(string repositoryPath);
+    public void CleanAndSwitchToDefaultBranch(string repositoryPath);
 
     public void SwitchToUpdateBranch(string repositoryPath, string projectName, string group);
 

--- a/src/DependencyUpdated.Core/Updater.cs
+++ b/src/DependencyUpdated.Core/Updater.cs
@@ -16,7 +16,7 @@ public sealed class Updater(IServiceProvider serviceProvider, IOptions<UpdaterCo
         var repositoryProvider =
             serviceProvider.GetRequiredKeyedService<IRepositoryProvider>(config.Value.RepositoryType);
         var repositoryPath = Environment.CurrentDirectory;
-        repositoryProvider.SwitchToDefaultBranch(repositoryPath);
+        repositoryProvider.CleanAndSwitchToDefaultBranch(repositoryPath);
 
         foreach (var project in config.Value.Projects)
         {
@@ -51,7 +51,7 @@ public sealed class Updater(IServiceProvider serviceProvider, IOptions<UpdaterCo
                     alreadyProcessed.AddRange(allDependenciesToUpdate);
                     repositoryProvider.CommitChanges(repositoryPath, projectName, group);
                     await repositoryProvider.SubmitPullRequest(allUpdates, projectName, group);
-                    repositoryProvider.SwitchToDefaultBranch(repositoryPath);
+                    repositoryProvider.CleanAndSwitchToDefaultBranch(repositoryPath);
                 }
             }
         }

--- a/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
+++ b/src/DependencyUpdated.Repositories.AzureDevOps/AzureDevOps.cs
@@ -20,11 +20,12 @@ internal sealed class AzureDevOps(TimeProvider timeProvider, IOptions<UpdaterCon
     private const string GitCommitMessage = "Bump dependencies";
     private const string RemoteName = "origin";
 
-    public void SwitchToDefaultBranch(string repositoryPath)
+    public void CleanAndSwitchToDefaultBranch(string repositoryPath)
     {
         var branchName = config.Value.AzureDevOps.TargetBranchName;
         logger.Information("Switching {Repository} to branch {Branch}", repositoryPath, branchName);
         using var repo = new Repository(repositoryPath);
+        repo.Reset(ResetMode.Hard);
         var branch = GetGitBranch(repo, branchName) 
                      ?? throw new InvalidOperationException($"Branch {branchName} doesn't exist");
 


### PR DESCRIPTION
Updated method `SwitchToDefaultBranch` to `CleanAndSwitchToDefaultBranch` to include a hard reset before switching branches. This ensures the repository is cleaned before branch switch to avoid conflicts and inconsistencies. Adjusted method calls and interface accordingly.