### PR TITLE
[codex] Fix noop commit branch cleanup

### DIFF
--- a/src/DependencyUpdated.Core/Updater.cs
+++ b/src/DependencyUpdated.Core/Updater.cs
@@ -60,6 +60,7 @@ public sealed class Updater(IServiceProvider serviceProvider, IOptions<UpdaterCo
                     if (!result)
                     {
                         logger.Debug("No changes detected. Skipping pull request");
+                        repositoryProvider.CleanAndSwitchToDefaultBranch(repositoryPath);
                         continue;
                     }
 

--- a/tests/DependencyUpdated.Core.UnitTests/UpdaterTests.cs
+++ b/tests/DependencyUpdated.Core.UnitTests/UpdaterTests.cs
@@ -525,4 +525,43 @@ public class UpdaterTests
                 _config.Value.Projects[0].Groups[0]);
         }
     }
+
+    [Fact]
+    public async Task Update_Should_CleanRepositoryAfterNoopCommit()
+    {
+        // Arrange
+        _config.Value.Projects[0].Version = VersionUpdateType.Major;
+        var projectList = new List<string>() { "TestProjectFile" };
+        _projectUpdater
+            .GetAllProjectFiles(_config.Value.Projects[0].Directories[0])
+            .Returns(projectList);
+        var projectDependencies =
+            new List<DependencyDetails>() { new("TestDependency", new Version(1, 0, 0)), };
+        _projectUpdater.ExtractAllPackages(projectList).Returns(projectDependencies);
+        _projectUpdater.GetVersions(projectDependencies[0], _config.Value.Projects[0])
+            .Returns(new List<DependencyDetails>
+            {
+                new(projectDependencies[0].Name, new Version(2, 0, 0)),
+                new(projectDependencies[0].Name, new Version(1, 1, 0)),
+                new(projectDependencies[0].Name, new Version(1, 0, 2)),
+            });
+
+        var expectedDependencyUpdate = new List<DependencyDetails>(new[]
+        {
+            new DependencyDetails(projectDependencies[0].Name, new Version(2, 0, 0))
+        });
+        var expectedUpdateResult = new List<UpdateResult> { new(projectDependencies[0].Name, "1.0.0", "2.0.0") };
+        _projectUpdater
+            .HandleProjectUpdate(_config.Value.Projects[0], projectList,
+                Arg.Is<ICollection<DependencyDetails>>(detailsCollection =>
+                    detailsCollection.SequenceEqual(expectedDependencyUpdate)))
+            .Returns(expectedUpdateResult);
+        _repositoryProvider.CommitChanges(_currentDir, _config.Value.Projects[0].Name, _config.Value.Projects[0].Groups[0]).Returns(false);
+
+        // Act
+        await _target.DoUpdate();
+
+        // Assert
+        _repositoryProvider.Received(2).CleanAndSwitchToDefaultBranch(_currentDir);
+    }
 }


### PR DESCRIPTION
## Summary
Fixes a regression from `efdee53` where `Updater.DoUpdate()` stayed on the update branch when `CommitChanges()` returned `false`.

## Changes
- restore `CleanAndSwitchToDefaultBranch()` before continuing on the no-op commit path
- add a regression test covering the no-op cleanup case

## Validation
- `dotnet test tests/DependencyUpdated.Core.UnitTests/DependencyUpdated.Core.UnitTests.csproj --filter "Update_Should_CleanRepositoryAfterNoopCommit"`
- `dotnet test DependencyUpdated.sln --nologo -v minimal`

## Notes
Local git push was blocked by a read-only credential, so the branch contents were published through the GitHub app connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling when commit operations fail—repositories are now properly cleaned and reset to the default branch instead of being left in an inconsistent state.

* **Tests**
  * Added test coverage to verify proper cleanup behavior when commits fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->