### PR TITLE
[codex] publish coverage summary for Dependabot PRs safely

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,28 +41,8 @@ jobs:
         title: dotnet code coverage
         reporttypes: 'MarkdownSummary;'
 
-    - name: Process coverage summary for normal PRs
-      if: ${{ github.actor != 'dependabot[bot]' }}
-      uses: im-open/process-code-coverage-summary@v2.2.3
+    - name: Upload coverage summary artifact
+      uses: actions/upload-artifact@v4
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        summary-file: './coverage-results/Summary.md'
-        create-status-check: true
-        create-pr-comment: true
-        update-comment-if-one-exists: true
-        update-comment-key: 'dotnet'
-        ignore-threshold-failures: false
-        line-threshold: 80
-        branch-threshold: 80
-    
-    - name: Process coverage summary for Dependabot
-      if: ${{ github.actor == 'dependabot[bot]' }}
-      uses: im-open/process-code-coverage-summary@v2.2.3
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        summary-file: './coverage-results/Summary.md'
-        create-status-check: false
-        create-pr-comment: false
-        ignore-threshold-failures: false
-        line-threshold: 80
-        branch-threshold: 80
+        name: coverage-results
+        path: ./coverage-results/Summary.md

--- a/.github/workflows/coverage-summary.yml
+++ b/.github/workflows/coverage-summary.yml
@@ -1,0 +1,41 @@
+name: Coverage Summary
+
+on:
+  workflow_run:
+    workflows: [ "CI" ]
+    types:
+      - completed
+
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+  actions: read
+
+jobs:
+  publish:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download coverage summary artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-results
+          path: ./coverage-results
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Process coverage summary
+        uses: im-open/process-code-coverage-summary@v2.2.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          summary-file: './coverage-results/Summary.md'
+          create-status-check: true
+          create-pr-comment: true
+          update-comment-if-one-exists: true
+          update-comment-key: 'dotnet'
+          ignore-threshold-failures: false
+          line-threshold: 80
+          branch-threshold: 80


### PR DESCRIPTION
## What changed
- Split coverage publishing out of the CI workflow.
- CI now generates the coverage summary and uploads it as an artifact.
- A new `workflow_run` workflow downloads that artifact and publishes the comment/status checks in a trusted context.

## Why
- Dependabot-triggered `pull_request` runs get a read-only token, so they cannot publish comments or status checks directly.
- This keeps the PR workflow unprivileged while still letting Dependabot PRs receive coverage feedback.

## Validation
- Verified the workflow diff locally.
- Ran `git diff --check`.

## Notes
- This avoids running Dependabot-supplied code in a privileged `pull_request_target` workflow.
